### PR TITLE
Update JTH.cls

### DIFF
--- a/resources/JTH.cls
+++ b/resources/JTH.cls
@@ -24,7 +24,7 @@
 \RequirePackage{geometry}
 \RequirePackage{tabularx}
 \RequirePackage{multicol}
-\RequirePackage{apacite}
+\RequirePackage[natbibapa]{apacite}
 \RequirePackage{caption}
 \RequirePackage[nottoc]{tocbibind}
 \RequirePackage[toc,page]{appendix}


### PR DESCRIPTION
Changes \RequirePackage{apacite} to \RequirePackage[natbibapa]{apacite}. This to make correct referencing when you first cite an article or paper with 3 to 5 authors.